### PR TITLE
Add a basic ci

### DIFF
--- a/.github/workflows/fixed_point_default.yml
+++ b/.github/workflows/fixed_point_default.yml
@@ -1,0 +1,32 @@
+name: Fixed Point Default
+
+on:
+  push:
+    paths:
+    - 'fixed_point/**'
+    - '!fixed_point/README.md'
+
+defaults:
+  run:
+    working-directory: fixed_point
+    shell: bash
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install cppcheck
+      run: sudo apt-get install cppcheck -y
+    - name: Run an analysis of the code
+      run: make check
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install googletest
+      run: sudo apt-get install googletest libgtest-dev -y
+    - name: Compile the code
+      run: make -j
+    - name: Run the Unit Tests
+      run: make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,58 @@
+name: Main Branch Event
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  poc-build:
+    defaults:
+      run:
+        working-directory: poc
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: npm ci
+    - name: Test building the application
+      run: npm run build
+    - name: Run the unit tests
+      run: npm test
+
+  fp-cppcheck:
+    defaults:
+      run:
+        working-directory: fixed_point
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install cppcheck
+      run: sudo apt-get install cppcheck -y
+    - name: Run an analysis of the code
+      run: make check
+
+  fp-build:
+    defaults:
+      run:
+        working-directory: fixed_point
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install googletest
+      run: sudo apt-get install googletest libgtest-dev -y
+    - name: Compile the code
+      run: make -j
+    - name: Run the Unit Tests
+      run: make test

--- a/.github/workflows/poc_default.yml
+++ b/.github/workflows/poc_default.yml
@@ -1,0 +1,29 @@
+name: PoC Default
+
+on:
+  push:
+    paths:
+    - 'poc/**'
+    - '!poc/README.md'
+
+defaults:
+  run:
+    working-directory: poc
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: npm ci
+    - name: Test building the application
+      run: npm run build
+    - name: Run the unit tests
+      run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # A naive CORDIC implementation
 
+[![main_ci](https://img.shields.io/github/workflow/status/baptistepetit/cordic/Main%20Branch%20Event)](https://github.com/baptistepetit/cordic/actions?query=workflow%3A%22Main+Branch+Event%22)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![License](https://img.shields.io/github/license/baptistepetit/cordic)](LICENSE)
 


### PR DESCRIPTION
Add a very simple CI to run linting build and testing.
Default actions are run on any branches depending on file changes.
Pull-requests and push to main are triggering rebuild of all sub-projects to ensure codebase stays consistent.
As of now, re-usability of job definitions does not seem fully supported in actions hence the configuration redundancy.